### PR TITLE
Fix bounding box in bud burst EML

### DIFF
--- a/R/budburst/03_budburst_create-EML-xml.R
+++ b/R/budburst/03_budburst_create-EML-xml.R
@@ -60,11 +60,11 @@ licensed <- list(licenseName = "Creative Commons Attribution 4.0 International (
                  url = "https://creativecommons.org/licenses/by/4.0/")
 
 # Geographic coverage of the data
-geographic_coverage <- list(geographicDescription = "Several sites across the Netherlands have been sampled: The Nationalpark Hoge Veluwe, Oosterhout, Warnsborn, Doorwerth, Bennekom, Buunderkamp, Wolfheze, Rhene, Heveadorp, Goffert, Kernhem, Loenen",
-                            boundingCoordinates = list(westBoundingCoordinate = "5.574453",
-                                                       eastBoundingCoordinate = "6.019378",
-                                                       northBoundingCoordinate = "52.116720",
-                                                       southBoundingCoordinate = "51.821770"))
+geographic_coverage <- list(geographicDescription = "Several sites across the Netherlands have been sampled: The Nationalpark Hoge Veluwe, Oosterhout, Warnsborn, Doorwerth, Bennekom, Buunderkamp, Wolfheze, Rhenen, Heveadorp, Goffert, Kernhem, Loenen",
+                            boundingCoordinates = list(westBoundingCoordinate = "5.5711",
+                                                       eastBoundingCoordinate = "6.0190",
+                                                       northBoundingCoordinate = "52.1164",
+                                                       southBoundingCoordinate = "51.8218"))
 
 # Temporal coverage of the data
 temporal_coverage <- list(rangeOfDates = list(beginDate = list(calendarDate = "1988-04-21"),


### PR DESCRIPTION
The bounding box coordinates in the bud burst EML are now set to the center point (based on Google maps) of the outermost study areas (as they do not have any trees with known coordinates). Precision is reduced to 4 decimals and typo fixed.